### PR TITLE
#1 Default compiler needs slash on the front

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -12,7 +12,7 @@ export default {
       title: 'Quartus Location',
       description: 'Path to Quartus install directory. Must be set before use',
       type: 'string',
-      default: 'intelFPGA_lite/18.0',
+      default: '/intelFPGA_lite/18.0',
       order: 0,
     },
     useModelSim: {


### PR DESCRIPTION
Added a slash to the front of the compiler so that it will be recognized as a path from the filesystem root. Corrects issue #1